### PR TITLE
fix(lyric): 修复多个流体云同时存在时识别出错

### DIFF
--- a/xposed/src/main/kotlin/io/github/proify/lyricon/xposed/systemui/util/OplusCapsuleHooker.kt
+++ b/xposed/src/main/kotlin/io/github/proify/lyricon/xposed/systemui/util/OplusCapsuleHooker.kt
@@ -39,6 +39,7 @@ object OplusCapsuleHooker {
 
     private var lastIsShowing: Boolean? = null
     private var unhook: XC_MethodHook.Unhook? = null
+    private var currentHook: SetVisibilityMethodHook? = null
 
     @SuppressLint("PrivateApi")
     fun isSupportCapsule(classLoader: ClassLoader): Boolean = try {
@@ -49,14 +50,17 @@ object OplusCapsuleHooker {
 
     fun initialize(classLoader: ClassLoader) {
         unhook?.unhook()
+        currentHook?.cleanup()
         if (!isSupportCapsule(classLoader)) return
 
+        val hook = SetVisibilityMethodHook()
+        currentHook = hook
         unhook = XposedHelpers.findAndHookMethod(
             classLoader.loadClass(
                 View::class.java.getName()
             ),
             "setVisibility",
-            Int::class.javaPrimitiveType, SetVisibilityMethodHook()
+            Int::class.javaPrimitiveType, hook
         )
     }
 
@@ -104,18 +108,31 @@ object OplusCapsuleHooker {
 
         /**
          * 检查追踪列表中是否有任意一个 view 处于 VISIBLE 状态。
+         * 同时遍历完整个列表以清理已被 GC 回收的 WeakReference。
          */
         private fun anyVisible(list: MutableList<WeakReference<View>>): Boolean {
             val iterator = list.iterator()
+            var visibleFound = false
             while (iterator.hasNext()) {
                 val ref = iterator.next().get()
                 if (ref == null) {
                     iterator.remove()
                 } else if (ref.visibility == View.VISIBLE) {
-                    return true
+                    visibleFound = true
                 }
             }
-            return false
+            return visibleFound
+        }
+
+        /**
+         * 清理所有状态：取消待执行的隐藏回调并清空追踪列表。
+         * 在 re-initialize / unhook 时调用，防止旧回调基于过期状态运行。
+         */
+        fun cleanup() {
+            pendingHideRunnable?.let { handler.removeCallbacks(it) }
+            pendingHideRunnable = null
+            capsuleViews.clear()
+            capsuleContainers.clear()
         }
 
         @Throws(Throwable::class)


### PR DESCRIPTION
Claude Code修的，我实际测试已经正常，存在多个流体云时歌词也能正常缩短。

补充：ColorOS不同应用流体云长度不一样🤣，所以音乐的不遮挡，其他app有可能遮挡。

## Bug 原因

原代码用单个布尔值 `capsuleViewVisible` 记录 CapsuleView 的可见性。ColorOS 多应用同时使用流体云时，SystemUI 会创建多个 CapsuleView 实例（日志中观察到 4 个），通过轮流切换它们的 visibility 来轮播不同应用的胶囊。最后一次 `setVisibility` 调用会覆盖之前的状态，导致某个 CapsuleView 变为 INVISIBLE 时，即使另一个 CapsuleView 仍然 VISIBLE，`isShowing` 也会被错误地置为 false。

## 修复方案

**1. 多实例追踪**

用 `WeakReference<View>` 列表替代单个布尔值，追踪所有 CapsuleView 和 CapsuleContainer 实例。判断逻辑改为：只要任意一个 CapsuleContainer 可见且任意一个 CapsuleView 可见，就认为流体云正在显示。

**2. 隐藏事件 debounce**

胶囊切换时，旧 CapsuleView INVISIBLE 和新 CapsuleView VISIBLE 的调用顺序不固定。当旧的先隐藏、新的后显示时，两次调用之间会出现所有 CapsuleView 都不可见的瞬态。因此对隐藏事件延迟 80ms 再触发，在此期间如果有新胶囊变为 VISIBLE 则取消隐藏。

**3. CapsuleContainer 隐藏立即响应**

用户点击展开流体云时 CapsuleContainer 变 GONE，代表流体云真正消失，此时跳过 debounce 立即响应，避免歌词恢复出现延迟